### PR TITLE
Add docs for Bill Actions validation

### DIFF
--- a/Bitcredit-Core/bill_validation.md
+++ b/Bitcredit-Core/bill_validation.md
@@ -36,6 +36,11 @@ Data validation (e.g. valid NodeIds, valid dates and currencies) are not part of
 
 ### General Conditions & Terms
 
+These are *very* important to understand the validation, since they concern all actions and are referenced in the validation conditions below.
+
+E.g. for `RequestToPay`, the only condition is, that none of the following general conditions apply, which means, you can't `RequestToPay` if the bill was **requested to pay** before, although that's not explicitly spelled out.
+The reason for this is, that `RequestToPay` can only be resolved by payment (**paid**), expiration or rejecting (**only recoursable**), which lead to one of the general conditions becoming true and hence would block another attempt to `RequestToPay`.
+
 * **paid** - If the bill is paid - no further actions can be taken by any participant
 * **recoursed to the end** - If the bill was recoursed to the end (i.e. the current holder does not have past endorsees to recourse against) - no further actions can be taken by any participant
 * **only recoursable** - If the bill was rejected to pay, rejected to accept, payment expired, or acceptance expired - the only actions that can be taken from this point are `RequestRecourse`, `Recourse`, `RejectToPayRecourse`

--- a/Bitcredit-Core/bill_validation.md
+++ b/Bitcredit-Core/bill_validation.md
@@ -27,3 +27,153 @@ stateDiagram-v2
     }
 
 ```
+
+## Bill Actions Validation
+
+This section describes which actions are possible by which bill participant depending on the state of the bill.
+
+Data validation (e.g. valid NodeIds, valid dates and currencies) are not part of this section - it's just about whether an action is possible for a given participant of the bill.
+
+### General Conditions & Terms
+
+* **paid** - If the bill is paid - no further actions can be taken by any participant
+* **recoursed to the end** - If the bill was recoursed to the end (i.e. the current holder does not have past endorsees to recourse against) - no further actions can be taken by any participant
+* **only recoursable** - If the bill was rejected to pay, rejected to accept, payment expired, or acceptance expired - the only actions that can be taken from this point are `RequestRecourse`, `Recourse`, `RejectToPayRecourse`
+* **blocked** - If the bill is in a waiting state - the only actions that can be taken are actions that resolve the waiting state
+    * waiting states are:
+        * Waiting for *payment* (triggered by `RequestToPay`), resolved by paying the bill, or `RejectToPay`, or deadline expiration
+        * Waiting for a *sale* (triggered by `OfferToSell`), resolved by `Sell`, or `RejectToBuy`, or deadline expiration
+        * Waiting for *recourse* (triggered by `RequestRecourse`), resolved by `Recourse`, or `RejectToPayRecourse`, or deadline expiration
+
+### Issue
+
+(Not that relevant here, since this is the first action to take.)
+
+The action can only be executed by the bill issuer.
+
+#### Conditions
+
+* The issuer can't be anonymous
+* The payer can't be the payee at time of issue
+
+### Holder Operations
+
+These are actions that can only be executed by the current bill holder
+
+#### RequestToAccept
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+* The bill can't already be **accepted**
+* The bill can't already be **requested to accept**
+
+#### RequestToPay
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+
+#### Endorse
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+
+#### OfferToSell
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+
+#### Sell
+
+##### Conditions
+
+* The bill has to be **waiting for sale** (unexpired, unrejected `OfferToSell` is the last block)
+* The bill can't be **waiting for payment**, or **waiting for recourse**
+* The bill can't be **recoursed to the end**, **only recoursable**, or **paid**
+
+#### Mint
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+* The bill has to be **accepted**
+
+#### RequestRecourse
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, or **paid**
+* There are two cases for Recourse - Acceptance and Payment
+    * Recourse for Acceptance
+        * The bill has to be either **rejected to accept**, or has to have an expired **request to accept** block
+    * Recourse for Payment
+        * The bill has to be either **rejected to pay**, or has to have an expired **request to pay** block
+
+#### Recourse
+
+##### Conditions
+
+* The bill has to be **waiting for recourse** (unexpired, unrejected `RequestRecourse` is the last block)
+* The bill can't be **waiting for payment**, or **waiting for sale**
+* The bill can't be **recoursed to the end**, or **paid**
+
+### Payer Operations
+
+These are actions that can only be executed by the bill payer.
+
+#### Accept
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+* The bill can't already be **accepted**
+
+#### RejectToAccept
+
+##### Conditions
+
+* The bill can't be **blocked**, **recoursed to the end**, **only recoursable**, or **paid**
+* The bill can't already be **accepted**
+
+#### RejectToPay
+
+##### Conditions
+
+* The bill has to be **waiting for payment** (unexpired, unrejected `RequestToPay` is the last block)
+* The bill can't be **waiting for sale**, or **waiting for recourse**
+* The bill can't be **recoursed to the end**, **only recoursable**, or **paid**
+
+### Buyer Operations
+
+These are actions that can only be executed by the bill buyer. (i.e. the `buyer` in the last unexpired `OfferToSell` block, if it's the last block)
+
+#### RejectToBuy
+
+##### Conditions
+
+* The bill has to be **waiting for sale** (unexpired, unrejected `OfferToSell` is the last block)
+* The bill can't be **waiting for payment**, or **waiting for recourse**
+* The bill can't be **recoursed to the end**, **only recoursable**, or **paid**
+* The bill can't already be **rejected to buy**
+
+### Recoursee Operations
+
+#### RejectToPayRecourse
+
+The action can only be executed by the recoursee. (i.e. the `recoursee` in the last unexpired `RequestRecourse` block, if it's the last block)
+
+##### Conditions
+
+* The bill has to be **waiting for recourse** (unexpired, unrejected `RequestRecourse` is the last block)
+* The bill can't be **waiting for payment**, or **waiting for sale**
+* The bill can't be **recoursed to the end**, or **paid**
+* The bill can't already be **rejected to recourse**
+
+### Special Case - Holder == Payer
+
+* If the holder is the payer at the same time (e.g. because the bill was endorsed back to the payer), they can do both **Holder Operations** and **Payer Operations**
+* e.g. they can both `RequestToAccept` and then `Accept` the bill
+

--- a/Bitcredit-Core/bill_validation.md
+++ b/Bitcredit-Core/bill_validation.md
@@ -59,6 +59,7 @@ The action can only be executed by the bill issuer.
 #### Conditions
 
 * The issuer can't be anonymous
+* The payer can't be anonymous
 * The payer can't be the payee at time of issue
 
 ### Holder Operations
@@ -179,6 +180,6 @@ The action can only be executed by the recoursee. (i.e. the `recoursee` in the l
 
 ### Special Case - Holder == Payer
 
-* If the holder is the payer at the same time (e.g. because the bill was endorsed back to the payer), they can do both **Holder Operations** and **Payer Operations**
-* e.g. they can both `RequestToAccept` and then `Accept` the bill
+* If the holder is the payer at the same time (e.g. because the bill was endorsed back to the payer), he can do both **Holder Operations** and **Payer Operations**
+* e.g. he can both `RequestToAccept` and then `Accept` the bill
 


### PR DESCRIPTION
### **User description**
Add docs for Bill Actions validation - describing which actions can be taken by which participants (holder, payer, buyer, recoursee) at different states of the bill.


___

### **PR Type**
Documentation


___

### **Description**
- Added comprehensive validation rules for bill actions across different states

- Documented participant-specific operations (holder, payer, buyer, recoursee)

- Defined general conditions including blocked, paid, and recoursed states

- Specified action prerequisites and state-dependent constraints


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bill States"] --> B["General Conditions"]
  B --> C["Holder Operations"]
  B --> D["Payer Operations"]
  B --> E["Buyer Operations"]
  B --> F["Recoursee Operations"]
  C --> G["RequestToAccept, RequestToPay, Endorse, etc."]
  D --> H["Accept, RejectToAccept, RejectToPay"]
  E --> I["RejectToBuy"]
  F --> J["RejectToPayRecourse"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bill_validation.md</strong><dd><code>Add bill actions validation rules documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Bitcredit-Core/bill_validation.md

<ul><li>Added comprehensive bill actions validation section with 150+ lines<br> <li> Documented general conditions (paid, recoursed, blocked states)<br> <li> Defined validation rules for holder operations (9 actions)<br> <li> Specified payer, buyer, and recoursee operation constraints</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/cats/pull/8/files#diff-f1bd049f1c5b5087e58ad5dd06d9fe576814c6392c028a10232555222a7fcb2e">+150/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

