### PR TITLE
Fix docs for recourse when payer is involved as previous endorsee, or holder

### DIFF
--- a/Bitcredit-Core/bill_actions.md
+++ b/Bitcredit-Core/bill_actions.md
@@ -88,12 +88,13 @@ The recoursee has to be a previous endorsee of the bill. This is calculated as f
    * For Endorse blocks, the holder is the endorsee
    * For Mint blocks, the holder is the mint
    * For Sell blocks, the holder is the buyer
-2. Iterate the holders until the caller finds themselves as a holder, which means we found the first block where the caller was a holder and they can only recourse against holders that held it *before* them
+2. Iterate the holders until the caller finds themselves as a holder or drawee, which means we found the first block where the caller was a holder and they can only recourse against holders that held it *before* them
    * While iterating the holders, we add all holders before the caller's first holder block
 3. If the caller was never a holder in the bill (e.g. if they are drawer & drawee) - they can't recourse against anyone
 4. If the drawer is not the same as the drawee, the bill drawer can also be recoursed against
 5. The caller is removed from the list (one can't recourse against oneself)
-6. The list is sorted by timestamp of endorsement descending
+6. The drawee is removed from the list (the drawee already rejected - otherwise no recourse would even happen, so recourse against them doesn't make sense)
+7. The list is sorted by timestamp of endorsement descending
 
 ##### Examples
 


### PR DESCRIPTION
### **User description**
Fix docs for recourse when payer is involved as previous endorsee, or holder


___

### **PR Type**
Documentation


___

### **Description**
- Updated recourse logic to include drawee as holder

- Clarified that drawee is excluded from recourse list

- Adjusted step numbering to reflect new exclusion rule


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Recourse Logic"] --> B["Find caller as holder or drawee"]
  B --> C["Collect previous holders"]
  C --> D["Remove caller from list"]
  D --> E["Remove drawee from list"]
  E --> F["Sort by timestamp"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bill_actions.md</strong><dd><code>Update recourse logic documentation for drawee handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

Bitcredit-Core/bill_actions.md

<ul><li>Modified step 2 to include drawee in addition to holder when <br>identifying first block<br> <li> Added new step 6 to explicitly remove drawee from recourse list<br> <li> Renumbered subsequent step from 6 to 7 for sorted timestamp<br> <li> Clarified that drawee exclusion is necessary since drawee already <br>rejected the bill</ul>


</details>


  </td>
  <td><a href="https://github.com/BitcreditProtocol/cats/pull/9/files#diff-4acfa88db86cde4036c76432c4f19d9240708a9cefafa5ec426078e81d80b84e">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

